### PR TITLE
Add missing secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
+          secrets: |
+            github=${{ secrets.GITHUB_TOKEN }}
           platforms: linux/amd64
           tags: |
             ghcr.io/${{ needs.preconditions.outputs.org_name }}/${{ needs.preconditions.outputs.repo_name }}:${{ needs.check-version.outputs.version }}


### PR DESCRIPTION
The release build failed because I missed a secret to add in the `release` workflow

https://github.com/digicatapult/dscp-ipfs/runs/6076870718?check_suite_focus=true