### PR TITLE
IN-154: bugfix when service goes offline.

### DIFF
--- a/app/keyWatcher/index.js
+++ b/app/keyWatcher/index.js
@@ -8,10 +8,14 @@ module.exports = {
     await setupKeyWatcher(api)({ onUpdate })
     return api
   },
-  nodeHealthCheck: async (api, name = 'substrate') => {
+  nodeHealthCheck: async (api = false, name = 'substrate') => {
     try {
-      if (!(await api._isConnected)) throw new ConnectionError({ name })
-      const [chain, runtime] = await Promise.all([api._runtimeChain, api._runtimeVersion])
+      if (!api) {
+        const { _api } = await createNodeApi()
+        api = _api
+      }
+      if (!(await api.isConnected)) throw new ConnectionError({ name })
+      const [chain, runtime] = await Promise.all([api.runtimeChain, api.runtimeVersion])
 
       return {
         name,

--- a/app/keyWatcher/index.js
+++ b/app/keyWatcher/index.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   nodeHealthCheck: async (api = false, name = 'substrate') => {
     try {
-      if (!api) {
+      if (!api.isReady) {
         const { _api } = await createNodeApi()
         api = _api
       }

--- a/app/server.js
+++ b/app/server.js
@@ -13,7 +13,7 @@ async function createHttpServer() {
   const ipfs = await setupIpfs()
 
   const sw = new ServiceWatcher({
-    substrate: { healthCheck: nodeHealthCheck },
+    substrate: { healthCheck: () => nodeHealthCheck({ isReady: false }) },
     ipfs: { healthCheck: () => ipfsHealthCheack(ipfs) },
   })
 

--- a/app/server.js
+++ b/app/server.js
@@ -16,7 +16,7 @@ async function createHttpServer() {
     substrate: { healthCheck: nodeHealthCheck },
     ipfs: { healthCheck: () => ipfsHealthCheack(ipfs) },
   })
-  
+
   await setupKeyWatcher({
     onUpdate: async (value) => {
       await ipfs.stop()

--- a/app/server.js
+++ b/app/server.js
@@ -12,24 +12,15 @@ async function createHttpServer() {
   const requestLogger = pinoHttp({ logger })
   const ipfs = await setupIpfs()
 
-  const nodeApi = await setupKeyWatcher({
+  const sw = new ServiceWatcher({
+    substrate: { healthCheck: nodeHealthCheck },
+    ipfs: { healthCheck: () => ipfsHealthCheack(ipfs) },
+  })
+  
+  await setupKeyWatcher({
     onUpdate: async (value) => {
       await ipfs.stop()
       await ipfs.start({ swarmKey: value })
-    },
-  })
-
-  // setup service watcher
-  // TODO add methdo foro addng service watcher so it can be done
-  // by calling sw.addService
-  const sw = new ServiceWatcher({
-    substrate: {
-      ...nodeApi._api,
-      healthCheck: nodeHealthCheck,
-    },
-    ipfs: {
-      ...ipfs,
-      healthCheck: ipfsHealthCheack,
     },
   })
 
@@ -66,8 +57,8 @@ async function startServer() {
       const server = app.listen(PORT, (err) => {
         if (err) return reject(err)
         logger.info(`Listening on port ${PORT} `)
-        resolve(server)
         sw.start()
+        resolve(server)
       })
 
       server.on('error', (err) => reject(err))

--- a/app/utils/ServiceWatcher.js
+++ b/app/utils/ServiceWatcher.js
@@ -62,7 +62,7 @@ class ServiceWatcher {
       }
 
       const { value } = this.gen.next()
-      recursive(value)
+      if (value) return recursive(value)
     }
 
     const { value } = this.gen.next()

--- a/app/utils/ServiceWatcher.js
+++ b/app/utils/ServiceWatcher.js
@@ -37,7 +37,7 @@ class ServiceWatcher {
         return healthCheck
           ? {
               name: service,
-              poll: () => healthCheck(api, service),
+              poll: () => healthCheck(false, service),
             }
           : null
       })

--- a/app/utils/ServiceWatcher.js
+++ b/app/utils/ServiceWatcher.js
@@ -37,7 +37,7 @@ class ServiceWatcher {
         return healthCheck
           ? {
               name: service,
-              poll: () => healthCheck(false, service),
+              poll: () => healthCheck(api),
             }
           : null
       })

--- a/helm/dscp-ipfs/Chart.yaml
+++ b/helm/dscp-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-ipfs
-appVersion: '2.0.4'
+appVersion: '2.0.5'
 description: A Helm chart for dscp-ipfs
-version: '2.0.4'
+version: '2.0.5'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-ipfs/values.yaml
+++ b/helm/dscp-ipfs/values.yaml
@@ -36,7 +36,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/dscp-ipfs
   pullPolicy: IfNotPresent
-  tag: 'v2.0.4'
+  tag: 'v2.0.5'
 
 storage:
   storageClass: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@digicatapult/dscp-ipfs",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Service for WASP",
   "main": "app/index.js",
   "scripts": {

--- a/test/__fixtures__/substrate-node-api-fn.js
+++ b/test/__fixtures__/substrate-node-api-fn.js
@@ -2,26 +2,26 @@ const { nodeHealthCheck } = require("../../app/keyWatcher")
 
 module.exports = {
   timeout: {
-    get _isConnected() {
+    get isConnected() {
       return new Promise(r => setTimeout(r, 5000))
     },
     healthCheck: nodeHealthCheck,
   },
   unavailable: {
-    get _isConnected() {
+    get isConnected() {
       return false
     },
     healthCheck: nodeHealthCheck,
   },
   available: {
     healthCheck: nodeHealthCheck,
-    get _isConnected() {
+    get isConnected() {
       return true
     },
-    get _runtimeChain() {
+    get runtimeChain() {
       return "Test"
     },
-    get _runtimeVersion() {
+    get runtimeVersion() {
       return {
         specName: "dscp-node",
         implName: "dscp-node",

--- a/test/__fixtures__/substrate-node-api-fn.js
+++ b/test/__fixtures__/substrate-node-api-fn.js
@@ -5,15 +5,18 @@ module.exports = {
     get isConnected() {
       return new Promise(r => setTimeout(r, 5000))
     },
+    isReady: true,
     healthCheck: nodeHealthCheck,
   },
   unavailable: {
+    isReady: true,
     get isConnected() {
       return false
     },
     healthCheck: nodeHealthCheck,
   },
   available: {
+    isReady: true,
     healthCheck: nodeHealthCheck,
     get isConnected() {
       return true


### PR DESCRIPTION
### What

Report was not updating when substrate node goes offline due to web socket connection and **isConnected** being false.

- Added another condition to check if nodeApi is defined and if not attempt to create a new nodeApi object

```sh
X-Powered-By: Express                                                                                                 
Content-Type: application/json; charset=utf-8                                                                         
Content-Length: 285                                                                                                   
ETag: W/"11d-ejaFJpbpm5LX9JyRH8A/+zS2SyQ"                                                                             
Date: Wed, 11 May 2022 08:51:47 GMT                                                                                   
Connection: keep-alive                                                                                                
Keep-Alive: timeout=5                                                                                                 
                                                                                                                      
{"substrate":{"status":"up","details":{"chain":"Development","runtime":{"name":"dscp","versions":{"spec":310,"impl":1,
"authoring":1,"transaction":1}}}},"ipfs":{"status":"error","error":{"service":"ipfs","message":"Connection is not esta
blished, will retry during next polling cycle"}}}

X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 273
ETag: W/"111-sWjMzcEhfloOh2QFUFLJuOEH8xo"
Date: Wed, 11 May 2022 09:24:14 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{"substrate":{"error":{"type":"TimeoutError","service":"substrate","message":"Timeout error, no response from a service"},"status":"error"},"ipfs":{"status":"error","error":{"service":"ipfs","message":"Connection is not established, will retry during next polling cycle"}}}~ $ 

```
