### PR TITLE
BUGFIX: fix ipfs properties.

### DIFF
--- a/app/ipfs.js
+++ b/app/ipfs.js
@@ -86,8 +86,8 @@ async function setupIpfs() {
 
 async function ipfsHealthCheack(api, name = 'ipfs') {
   try {
-    if (!api || !api.pid) throw new ConnectionError({ name })
-    const { spawnfile, pid, killed } = api
+    if (!api.ipfs || !api.ipfs.pid) throw new ConnectionError({ name })
+    const { spawnfile, pid, killed } = api.ipfs
 
     return {
       name,

--- a/app/ipfs.js
+++ b/app/ipfs.js
@@ -84,7 +84,7 @@ async function setupIpfs() {
   return that
 }
 
-async function ipfsHealthCheack(api, name = 'ipfs') {
+async function ipfsHealthCheack(api = {}, name = 'ipfs') {
   try {
     if (!api.ipfs || !api.ipfs.pid) throw new ConnectionError({ name })
     const { spawnfile, pid, killed } = api.ipfs

--- a/app/server.js
+++ b/app/server.js
@@ -4,6 +4,7 @@ const pinoHttp = require('pino-http')
 const { PORT } = require('./env')
 const logger = require('./logger')
 const { setupKeyWatcher, nodeHealthCheck } = require('./keyWatcher')
+const { ipfsHealthCheack } = require('./ipfs')
 const { setupIpfs } = require('./ipfs')
 const ServiceWatcher = require('./utils/ServiceWatcher')
 

--- a/app/server.js
+++ b/app/server.js
@@ -14,8 +14,7 @@ async function createHttpServer() {
 
   const sw = new ServiceWatcher({
     substrate: { healthCheck: () => nodeHealthCheck({ isReady: false }) },
-    // TODO temporary commenting out so I can investigate the health helch foor ipfs
-    // ipfs: { healthCheck: () => ipfsHealthCheack(ipfs) },
+    ipfs: { healthCheck: () => ipfsHealthCheack(ipfs) },
   })
 
   await setupKeyWatcher({

--- a/helm/dscp-ipfs/Chart.yaml
+++ b/helm/dscp-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-ipfs
-appVersion: '2.1.1'
+appVersion: '2.1.2'
 description: A Helm chart for dscp-ipfs
-version: '2.1.1'
+version: '2.1.2'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-ipfs/values.yaml
+++ b/helm/dscp-ipfs/values.yaml
@@ -37,7 +37,7 @@ config:
 image:
   repository: ghcr.io/digicatapult/dscp-ipfs
   pullPolicy: IfNotPresent
-  tag: 'v2.1.1'
+  tag: 'v2.1.2'
 
 storage:
   storageClass: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Service for WASP",
   "main": "app/index.js",
   "scripts": {

--- a/test/__fixtures__/ipfs-api-fn.js
+++ b/test/__fixtures__/ipfs-api-fn.js
@@ -2,9 +2,11 @@ const { ipfsHealthCheack } = require('../../app/ipfs');
 
 module.exports = {
   available: {
-    pid: 10,
-    spawnfile: '/path/to/file/test/spawn.key',
-    killed: false,
+    ipfs: {
+      pid: 10,
+      spawnfile: '/path/to/file/test/spawn.key',
+      killed: false,
+    },
     healthCheck: ipfsHealthCheack,
   }
 }


### PR DESCRIPTION
### What

Ipfs service check was failing with connection error and returning 503 as a result. This was blocking a deployment of cluster due to failing health check.

Missed a property `ipfs`

A complete wrapped response:
```json
{
      "_events": {},
      "_eventsCount": 1,
      "ipfs": {
        "_events": {},
        "_eventsCount": 1,
        "_closesNeeded": 3,
        "_closesGot": 0,
        "connected": false,
        "signalCode": null,
        "exitCode": null,
        "killed": false,
        "spawnfile": "ipfs",
        "_handle": {
          "pid": 18
        },
        "spawnargs": [
          "ipfs",
          "daemon"
        ],
        ....
```