### PR TITLE
Upgrade go-ipfs version to at least 13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache git make bash gcc musl-dev
 
 WORKDIR /target
 
-ARG IPFS_TAG="v0.10.0"
+ARG IPFS_TAG="v0.13.1"
 
 RUN <<EOF
 set -ex

--- a/app/env.js
+++ b/app/env.js
@@ -28,7 +28,7 @@ const vars = envalid.cleanEnv(
       default: 'ipfs',
       devDefault: path.resolve(__dirname, '..', `node_modules`, '.bin', 'ipfs'),
     }),
-    IPFS_ARGS: validateArgs({ default: '["daemon"]' }),
+    IPFS_ARGS: validateArgs({ default: '["daemon", "--migrate"]' }),
     IPFS_LOG_LEVEL: envalid.str({ default: 'info', devDefault: 'debug' }),
     HEALTHCHECK_POLL_PERIOD_MS: envalid.num({ default: 30 * 1000, devDefault: 1000 }),
     HEALTHCHECK_TIMEOUT_MS: envalid.num({ default: 2 * 1000, devDefault: 1000 }),

--- a/app/keyWatcher/index.js
+++ b/app/keyWatcher/index.js
@@ -3,17 +3,12 @@ const { setupKeyWatcher } = require('./keyWatcher')
 const { ConnectionError } = require('../utils/Errors')
 
 module.exports = {
-  setupKeyWatcher: async ({ onUpdate }) => {
-    const api = await createNodeApi()
+  createNodeApi,
+  setupKeyWatcher: async ({ api, onUpdate }) => {
     await setupKeyWatcher(api)({ onUpdate })
-    return api
   },
-  nodeHealthCheck: async (api = false, name = 'substrate') => {
+  nodeHealthCheck: async (api, name = 'substrate') => {
     try {
-      if (!api.isReady) {
-        const { _api } = await createNodeApi()
-        api = _api
-      }
       if (!(await api.isConnected)) throw new ConnectionError({ name })
       const [chain, runtime] = await Promise.all([api.runtimeChain, api.runtimeVersion])
 

--- a/helm/dscp-ipfs/Chart.yaml
+++ b/helm/dscp-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-ipfs
-appVersion: '2.5.0'
+appVersion: '2.6.0'
 description: A Helm chart for dscp-ipfs
-version: '2.5.0'
+version: '2.6.0'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-ipfs/values.yaml
+++ b/helm/dscp-ipfs/values.yaml
@@ -14,6 +14,7 @@ config:
   ipfsCommand: "/usr/local/bin/ipfs"
   ipfsArgs:
     - daemon
+    - "--migrate"
   # ipfsBootNodeAddress: /dnsaddr/blah.test.com/p2p/PeerId # Valid Format for this is /multiaddr/PeerId see https://github.com/multiformats/multiaddr
   ipfsLogLevel: info
   ipfsSwarmAddrFilters:
@@ -51,7 +52,7 @@ statefulSet:
 image:
   repository: digicatapult/dscp-ipfs
   pullPolicy: IfNotPresent
-  tag: 'v2.5.0'
+  tag: 'v2.6.0'
 
 storage:
   storageClass: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-ipfs",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@digicatapult/dscp-node": "^4.2.1",
@@ -25,7 +25,7 @@
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-prettier": "^3.3.1",
         "form-data": "^3.0.1",
-        "go-ipfs": "^0.11.0",
+        "go-ipfs": "^0.13.1",
         "mocha": "^9.2.0",
         "node-fetch": "npm:@achingbrain/node-fetch@^2.6.7",
         "nodemon": "^2.0.19",
@@ -3439,15 +3439,13 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.11.0.tgz",
-      "integrity": "sha512-l6uZTeEZYQQpKsoI8DXV5j1UDiq7xTIwNyp5lGJmY1cR9LoWHR4lIhbSpc2DfvOv5Ly/+BC/CLvo7vIFmdmyGQ==",
-      "deprecated": "Version no longer supported. Upgrade to 0.12.2 or later.",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.13.1.tgz",
+      "integrity": "sha512-LW8BKQ7DGEb0fFKlBXU8QGhr2XVoex9N7hJ7rehOYEA+t/O5KzK3OFqSIwa+S2KSwejJlAocqgf0i6/1Fj5ufA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",
-        "go-platform": "^1.0.0",
         "got": "^11.7.0",
         "gunzip-maybe": "^1.4.2",
         "hasha": "^5.2.2",
@@ -3457,15 +3455,6 @@
       },
       "bin": {
         "ipfs": "bin/ipfs"
-      }
-    },
-    "node_modules/go-platform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/go-platform/-/go-platform-1.0.0.tgz",
-      "integrity": "sha1-sF/2uSdAB9JGsWQjXwP39qWWJsc=",
-      "dev": true,
-      "bin": {
-        "go-platform": "cli.js"
       }
     },
     "node_modules/got": {
@@ -9490,13 +9479,12 @@
       "dev": true
     },
     "go-ipfs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.11.0.tgz",
-      "integrity": "sha512-l6uZTeEZYQQpKsoI8DXV5j1UDiq7xTIwNyp5lGJmY1cR9LoWHR4lIhbSpc2DfvOv5Ly/+BC/CLvo7vIFmdmyGQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.13.1.tgz",
+      "integrity": "sha512-LW8BKQ7DGEb0fFKlBXU8QGhr2XVoex9N7hJ7rehOYEA+t/O5KzK3OFqSIwa+S2KSwejJlAocqgf0i6/1Fj5ufA==",
       "dev": true,
       "requires": {
         "cachedir": "^2.3.0",
-        "go-platform": "^1.0.0",
         "got": "^11.7.0",
         "gunzip-maybe": "^1.4.2",
         "hasha": "^5.2.2",
@@ -9504,12 +9492,6 @@
         "tar-fs": "^2.1.0",
         "unzip-stream": "^0.3.0"
       }
-    },
-    "go-platform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/go-platform/-/go-platform-1.0.0.tgz",
-      "integrity": "sha1-sF/2uSdAB9JGsWQjXwP39qWWJsc=",
-      "dev": true
     },
     "got": {
       "version": "11.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Service for DSCP",
   "main": "app/index.js",
   "scripts": {
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "form-data": "^3.0.1",
-    "go-ipfs": "^0.11.0",
+    "go-ipfs": "^0.13.1",
     "mocha": "^9.2.0",
     "node-fetch": "npm:@achingbrain/node-fetch@^2.6.7",
     "nodemon": "^2.0.19",


### PR DESCRIPTION
Upgrades the `go-ipfs` version to `13.1`. Also fixes a bug with the healthcheck where it keeps creating a new connection each time, effectively DoS attacking the node