### PR TITLE
Replace dscp-node package with @polkadot/api

### DIFF
--- a/app/keyWatcher/api.js
+++ b/app/keyWatcher/api.js
@@ -1,20 +1,18 @@
-import { buildApi } from '@digicatapult/dscp-node'
+import { ApiPromise, WsProvider, Keyring } from '@polkadot/api'
 
 import env from '../env.js'
 
 export const createNodeApi = async () => {
-  const { api, keyring } = buildApi({
-    options: {
-      apiHost: env.NODE_HOST,
-      apiPort: env.NODE_PORT,
-    },
-  })
+  const provider = new WsProvider(`ws://${env.NODE_HOST}:${env.NODE_PORT}`)
+  const api = new ApiPromise({ provider })
+
+  api.isReadyOrError.catch(() => {}) // prevent unhandled promise rejection errors
 
   await api.isReady
 
   return {
     _api: api,
-    _keyring: keyring,
+    _keyring: new Keyring({ type: 'sr25519' }),
     isEventKeyUpdate: (event) => api.events.ipfsKey.UpdateKey.is(event),
     getCurrentKey: async () => await api.query.ipfsKey.key(),
     setupEventProcessor: (eventProcessor) => api.query.system.events(eventProcessor),

--- a/app/keyWatcher/api.js
+++ b/app/keyWatcher/api.js
@@ -6,9 +6,7 @@ export const createNodeApi = async () => {
   const provider = new WsProvider(`ws://${env.NODE_HOST}:${env.NODE_PORT}`)
   const api = new ApiPromise({ provider })
 
-  api.isReadyOrError.catch(() => {}) // prevent unhandled promise rejection errors
-
-  await api.isReady
+  await api.isReadyOrError.catch(() => {}) // prevent unhandled promise rejection errors
 
   return {
     _api: api,

--- a/helm/dscp-ipfs/Chart.yaml
+++ b/helm/dscp-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-ipfs
-appVersion: '2.8.1'
+appVersion: '2.8.2'
 description: A Helm chart for dscp-ipfs
-version: '2.8.1'
+version: '2.8.2'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-ipfs/values.yaml
+++ b/helm/dscp-ipfs/values.yaml
@@ -52,7 +52,7 @@ statefulSet:
 image:
   repository: digicatapult/dscp-ipfs
   pullPolicy: IfNotPresent
-  tag: 'v2.8.1'
+  tag: 'v2.8.2'
 
 storage:
   storageClass: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@digicatapult/dscp-node": "^4.4.6",
+        "@polkadot/api": "^9.9.4",
         "dotenv": "^16.0.3",
         "envalid": "^7.3.1",
         "express": "^4.18.2",
@@ -326,11 +326,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -383,18 +383,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@digicatapult/dscp-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.4.6.tgz",
-      "integrity": "sha512-h8R2h9mfW3YrhwZ3P3KPKV+uGOlj6kIMBXv7vQmg9cA+0yCBUHHUNwUQp7jpudV7cpTFzV6QNSw9k21IrTGi/w==",
-      "dependencies": {
-        "@polkadot/api": "^8.11.3"
-      },
-      "engines": {
-        "node": "16.x.x",
-        "npm": "8.x.x"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -707,160 +695,160 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.4.tgz",
+      "integrity": "sha512-ze7W/DXsPHsixrFOACzugDQqezzrUGGX1Z2JOl6z+V8pd+ZKLSecsKJFUzf4yoBT82ArITYPtRVx/Dq9b9K2dA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/api-derive": "9.9.4",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/types-known": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.4.tgz",
+      "integrity": "sha512-+T9YWw5kEi7AkSoS2UfE1nrVeJUtD92elQBZ3bMMkfM1geKWhSnvBLyTMn6kFmNXTfK0qt8YKS1pwbux7cC9tg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.4.tgz",
+      "integrity": "sha512-G1DcxcMeGcvaAAA3u5Tbf70zE5aIuAPEAXnptFMF0lvJz4O6CM8k8ZZFTSk25hjsYlnx8WI1FTc97q4/tKie+Q==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.4.tgz",
+      "integrity": "sha512-3ka7GzY4QbI3d/DHjQ9SjfDOTDxeU8gM2Dn31BP1oFzGwdFe2GZhDIE//lR5S6UDVxNNlgWz4927AunOQcuAmg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.4",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.11.tgz",
-      "integrity": "sha512-Nv8cZaOA/KbdslDMTklJ58+y+UPpic3+oMQoozuq48Ccjv7WeW2BX47XM/RNE8nYFg6EHa6Whfm4IFaFb8s7ag==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.14.tgz",
+      "integrity": "sha512-iejbAfGfdyTB0pixWX6HhWXkUKBHLNy7+Z+F4DU8IwpJE48iOsMRJb3qShbk5NERjx1QIjoOpSZYxiCaF6gd+w==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/util": "10.1.11",
-        "@polkadot/util-crypto": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.11",
-        "@polkadot/util-crypto": "10.1.11"
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.11.tgz",
-      "integrity": "sha512-4FfOVETXwh6PL6wd6fYJMkRSQKm+xUw3vR5rHqcAnB696FpMFPPErc6asgZ9lYMyzNJRY3yG86HQpFhtCv1nGA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.14.tgz",
+      "integrity": "sha512-lo4Y57yBqiad4Z2zBW0r7Ct/iKXNgsTfazDTbHRkIh3RuX36PNYshaX3p7R0eNRuetV1jJv7jqwc1nAMNI2KwQ==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/util": "10.1.11",
-        "@substrate/ss58-registry": "^1.33.0"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@substrate/ss58-registry": "^1.35.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.4.tgz",
+      "integrity": "sha512-67zGQAhJuXd/CZlwDZTgxNt3xGtsDwLvLvyFrHuNjJNM0KGCyt/OpQHVBlyZ6xfII0WZpccASN6P2MxsGTMnKw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.4.tgz",
+      "integrity": "sha512-DxhJcq1GAi+28nLMqhTksNMqTX40bGNhYuyQyy/to39VxizAjx+lyAHAMfzG9lvPnTIi2KzXif2pCdWq3AgJag==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.4.tgz",
+      "integrity": "sha512-aUkPtlYukAOFX3FkUgLw3MNy+T0mCiCX7va3PIts9ggK4vl14NFZHurCZq+5ANvknRU4WG8P5teurH9Rd9oDjQ==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-support": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "@polkadot/x-fetch": "^10.1.14",
+        "@polkadot/x-global": "^10.1.14",
+        "@polkadot/x-ws": "^10.1.14",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
@@ -870,101 +858,101 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.4.tgz",
+      "integrity": "sha512-/LJ029S0AtKzvV9JoQtIIeHRP/Xoq8MZmDfdHUEgThRd+uvtQzFyGmcupe4EzX0p5VAx93DUFQKm8vUdHE39Tw==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.4.tgz",
+      "integrity": "sha512-mQNc0kxt3zM6SC+5hJbsg03fxEFpn5nakki+loE2mNsWr1g+rR7LECagAZ4wT2gvdbzWuY/LlRYyDQxe0PwdZg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.4.tgz",
+      "integrity": "sha512-uSHoQQcj4813c9zNkDDH897K6JB0OznTrH5WeZ1wxpjML7lkuTJ2t/GQE9e4q5Ycl7YePZsvEp2qlc3GwrVm/w==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/x-bigint": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.4.tgz",
+      "integrity": "sha512-EOxLryRQ4JVRSRnIMXk3Tjry1tyegNuWK8OUj51A1wHrX76DF9chME27bXUP4d7el1pjqPuQ9/l+/928GG386g==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.4.tgz",
+      "integrity": "sha512-BaKXkg3yZLDv31g0CZPJsZDXX01VTjkQ0tmW9U6fmccEq3zHlxbUiXf3aKlwKRJyDWiEOxr4cQ4GT8jj6uEIuA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.4.tgz",
+      "integrity": "sha512-vjhdD7B5kdTLhm2iO0QAb7fM4D2ojNUVVocOJotC9NULYtoC+PkPvkvFbw7VQ1H3u7yxyZfWloMtBnCsIp5EAA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.11.tgz",
-      "integrity": "sha512-6m51lw6g6ilqO/k4BQY7rD0lYM9NCnC4FiM7CEEUc7j8q86qxdcZ88zdNldkhNsTIQnfmCtkK3GRzZW6VYrbUw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.14.tgz",
+      "integrity": "sha512-DX8IUd3j+S4HJBs73gz5d7Z592aW5vn/aD7hzFUlBduQIYBy+L1KIoGchpD6hSSOs5HSy7owePmBlp1lPjUZBg==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-bigint": "10.1.11",
-        "@polkadot/x-global": "10.1.11",
-        "@polkadot/x-textdecoder": "10.1.11",
-        "@polkadot/x-textencoder": "10.1.11",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-global": "10.1.14",
+        "@polkadot/x-textdecoder": "10.1.14",
+        "@polkadot/x-textencoder": "10.1.14",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       },
@@ -973,18 +961,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.11.tgz",
-      "integrity": "sha512-wG63frIMAR5T/HXGM0SFNzZZdk7qDBsfLXfn6PIZiXCCCsdEYPzS5WltB7fkhicYpbePJ7VgdCAddj1l4IcGyg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.14.tgz",
+      "integrity": "sha512-Iq9C0Snv+pScZ9QgJoH7l++x9wdp9vhS3NMLm8ZqlDCNXUUl/3ViafZCfHRILQD9AsLcykE99mNzFDl3u8jZQA==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
+        "@babel/runtime": "^7.20.1",
         "@noble/hashes": "1.1.3",
         "@noble/secp256k1": "1.7.0",
-        "@polkadot/networks": "10.1.11",
-        "@polkadot/util": "10.1.11",
+        "@polkadot/networks": "10.1.14",
+        "@polkadot/util": "10.1.14",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.11",
-        "@polkadot/x-randomvalues": "10.1.11",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-randomvalues": "10.1.14",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -993,7 +981,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.1.11"
+        "@polkadot/util": "10.1.14"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -1093,85 +1081,85 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.11.tgz",
-      "integrity": "sha512-TC4KZ+ni/SJhcf/LIwD49C/kwvACu0nCchETNO+sAfJ7COXZwHDUJXVXmwN5PgkQxwsWsKKuJmzR/Fi1bgMWnQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.14.tgz",
+      "integrity": "sha512-HgrofhI+WM699ozJ9zFZcPUApB2jqwCEOMUgM1jv2WNxF0ILKNDpH08dB8OBy2SKfnKoSgmXwWtxWl1u+mq10A==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.11.tgz",
-      "integrity": "sha512-WtyUr9itVD9BLnxCUloJ1iwrXOY/lnlEShEYKHcSm6MIHtbJolePd3v1+o5mOX+bdDbHXhPZnH8anCCqDNDRqg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.14.tgz",
+      "integrity": "sha512-07H9unwv0tT5RQRkj1WE67ug6x6RlUfGN/mJWSKqf0JjsfQlPMKDC9yZW1oUSsasBUyIf0qbspuVSyhZu+0cpg==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/node-fetch": "^2.6.2",
-        "node-fetch": "^3.2.10"
+        "node-fetch": "^3.3.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.11.tgz",
-      "integrity": "sha512-bWz5gdcELy6+xfr27R1GE5MPX4nfVlchzHQH+DR6OBbSi9g/PeycQAvFB6IkTmP+YEbNNtIpxnSP37zoUaG3xw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.14.tgz",
+      "integrity": "sha512-ye3Yx2bfIoHf5t78rbDad587J16JanrcfpGSWoknWOZ7wmatj/CJKWhJ/VKMPfJGEJm2LidH1B0W8QDfrMEmTA==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4"
+        "@babel/runtime": "^7.20.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.11.tgz",
-      "integrity": "sha512-V2V37f5hoM5B32eCpGw87Lwstin2+ArXhOZ8ENKncbQLXzbF9yTODueDoA5Vt0MJCs2CDP9cyiCYykcanqVkxg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.14.tgz",
+      "integrity": "sha512-mrZho4qogLZmox7wuP1XF03HTZ4CwAjzV7RvKmwH8ToNCR6E4NRo2btgG67Z0K+bUOQRbXWL2hQazusa2p2N6w==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.11.tgz",
-      "integrity": "sha512-QZqie04SR6pAj260PaLBfZUGXWKI357t4ROVJhpaj06qc1zrk1V8Mwkr49+WzjAPFEOqo70HWnzXmPNCH4dQiw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.14.tgz",
+      "integrity": "sha512-qwbeR8v6a5Z9MdbjzcY5gFiRWbp8bBVoDEf1Dd+yH9/UAyFXodlMKs3irDdVhGVPCbZWQTVDEZRUgEqRxwKC7w==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.11.tgz",
-      "integrity": "sha512-UX+uV9AbDID81waaG/NvTkkf7ZNVW7HSHaddgbWjQEVW2Ex4ByccBarY5jEi6cErEPKfzCamKhgXflu0aV9LWw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.14.tgz",
+      "integrity": "sha512-MC30rtQiFVgQDSP8wO5wa1so5tW3T7qs/DCT018A4zgjiK+uFdIGOerAgoxcNw3yC6IGnPIL5lsRO/1C9N60zA==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.11.tgz",
-      "integrity": "sha512-EUbL/R1A/NxYf6Rnb1M7U9yeTuo5r4y2vcQllE5aBLaQ0cFnRykHzlmZlVX1E7O5uy3lYVdxWC7sNgxItIWkWA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.14.tgz",
+      "integrity": "sha512-xgyMYR34sHxKCtQUJ2btFAyN3fK1OqCqvAyRYmU52801aguLstRhVPAZxXJp3Dahs91FX/h/ZZzmwXD01tJtyA==",
       "dependencies": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       },
@@ -1238,12 +1226,12 @@
       "dev": true
     },
     "node_modules/@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "dependencies": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -1253,17 +1241,23 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "node_modules/@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "dependencies": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
       }
     },
+    "node_modules/@substrate/smoldot-light/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.33.0.tgz",
-      "integrity": "sha512-DztMuMcEfu+tJrtIQIIp5gO8/XJZ8N8UwPObDCSNgrp7trtSkPJAUFB9qXaReXtN9UvTcVBMTWk6VPfFi04Wkg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -1850,9 +1844,9 @@
       }
     },
     "node_modules/bufferutil": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
-      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -4842,9 +4836,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -6117,9 +6111,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -6969,9 +6963,9 @@
       }
     },
     "node_modules/utf-8-validate": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
-      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -7151,6 +7145,26 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {
@@ -7472,11 +7486,11 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
-      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
+      "version": "7.20.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.6.tgz",
+      "integrity": "sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
@@ -7517,14 +7531,6 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@digicatapult/dscp-node": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@digicatapult/dscp-node/-/dscp-node-4.4.6.tgz",
-      "integrity": "sha512-h8R2h9mfW3YrhwZ3P3KPKV+uGOlj6kIMBXv7vQmg9cA+0yCBUHHUNwUQp7jpudV7cpTFzV6QNSw9k21IrTGi/w==",
-      "requires": {
-        "@polkadot/api": "^8.11.3"
       }
     },
     "@eslint/eslintrc": {
@@ -7753,232 +7759,232 @@
       }
     },
     "@polkadot/api": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-8.14.1.tgz",
-      "integrity": "sha512-jg26eIKFYqVfDBTAopHL3aDaNw9j6TdUkXuvYJOnynpecU4xwbTVKcOtSOjJ2eRX4MgMQ4zlyMHJx3iKw0uUTA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.9.4.tgz",
+      "integrity": "sha512-ze7W/DXsPHsixrFOACzugDQqezzrUGGX1Z2JOl6z+V8pd+ZKLSecsKJFUzf4yoBT82ArITYPtRVx/Dq9b9K2dA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/api-derive": "8.14.1",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/types-known": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/api-derive": "9.9.4",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/types-known": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
         "eventemitter3": "^4.0.7",
-        "rxjs": "^7.5.6"
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-8.14.1.tgz",
-      "integrity": "sha512-65GMlgVnZd08Ifh8uAj+p/+MlXxvsAfBcCHjQhOmbCE0dki+rzTPUR31LsWyDKtuw+nUBj0iZN4PelO+wU4r0g==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.9.4.tgz",
+      "integrity": "sha512-+T9YWw5kEi7AkSoS2UfE1nrVeJUtD92elQBZ3bMMkfM1geKWhSnvBLyTMn6kFmNXTfK0qt8YKS1pwbux7cC9tg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/api-base": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-8.14.1.tgz",
-      "integrity": "sha512-EXFhNXIfpirf18IsqcG2pGQW1/Xn+bfjqVYQMMJ4ZONtYH4baZZlXk7SoXCCHonN2x1ixs4DOcRx5oVxjabdIQ==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.9.4.tgz",
+      "integrity": "sha512-G1DcxcMeGcvaAAA3u5Tbf70zE5aIuAPEAXnptFMF0lvJz4O6CM8k8ZZFTSk25hjsYlnx8WI1FTc97q4/tKie+Q==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/api-derive": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-8.14.1.tgz",
-      "integrity": "sha512-eWG1MrQhHMUjt9gDHN9/9/ZMATu1MolqcalPFhNoGtdON3+I0J3ntjQ4y5X7+p2OGwQplpYRKqbK4k7tKzu8tA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.9.4.tgz",
+      "integrity": "sha512-3ka7GzY4QbI3d/DHjQ9SjfDOTDxeU8gM2Dn31BP1oFzGwdFe2GZhDIE//lR5S6UDVxNNlgWz4927AunOQcuAmg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/api": "8.14.1",
-        "@polkadot/api-augment": "8.14.1",
-        "@polkadot/api-base": "8.14.1",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/api": "9.9.4",
+        "@polkadot/api-augment": "9.9.4",
+        "@polkadot/api-base": "9.9.4",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/keyring": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.11.tgz",
-      "integrity": "sha512-Nv8cZaOA/KbdslDMTklJ58+y+UPpic3+oMQoozuq48Ccjv7WeW2BX47XM/RNE8nYFg6EHa6Whfm4IFaFb8s7ag==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.1.14.tgz",
+      "integrity": "sha512-iejbAfGfdyTB0pixWX6HhWXkUKBHLNy7+Z+F4DU8IwpJE48iOsMRJb3qShbk5NERjx1QIjoOpSZYxiCaF6gd+w==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/util": "10.1.11",
-        "@polkadot/util-crypto": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@polkadot/util-crypto": "10.1.14"
       }
     },
     "@polkadot/networks": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.11.tgz",
-      "integrity": "sha512-4FfOVETXwh6PL6wd6fYJMkRSQKm+xUw3vR5rHqcAnB696FpMFPPErc6asgZ9lYMyzNJRY3yG86HQpFhtCv1nGA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.1.14.tgz",
+      "integrity": "sha512-lo4Y57yBqiad4Z2zBW0r7Ct/iKXNgsTfazDTbHRkIh3RuX36PNYshaX3p7R0eNRuetV1jJv7jqwc1nAMNI2KwQ==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/util": "10.1.11",
-        "@substrate/ss58-registry": "^1.33.0"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "10.1.14",
+        "@substrate/ss58-registry": "^1.35.0"
       }
     },
     "@polkadot/rpc-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-8.14.1.tgz",
-      "integrity": "sha512-0dIsNVIMeCp0kV7+Obz0Odt6K32Ka2ygwhiV5jhhJthy8GJBPo94mKDed5gzln3Dgl2LEdJJt1h/pgCx4a2i4A==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.9.4.tgz",
+      "integrity": "sha512-67zGQAhJuXd/CZlwDZTgxNt3xGtsDwLvLvyFrHuNjJNM0KGCyt/OpQHVBlyZ6xfII0WZpccASN6P2MxsGTMnKw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-core": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-core": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/rpc-core": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-8.14.1.tgz",
-      "integrity": "sha512-deQ8Ob59ao/1fZQdaVtFjYR/HCBdxSYvQGt7/alBu1Uig9Sahx9oKcMkU5rWY36XqGZYos4zLay98W2hDlf+6Q==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.9.4.tgz",
+      "integrity": "sha512-DxhJcq1GAi+28nLMqhTksNMqTX40bGNhYuyQyy/to39VxizAjx+lyAHAMfzG9lvPnTIi2KzXif2pCdWq3AgJag==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/rpc-augment": "8.14.1",
-        "@polkadot/rpc-provider": "8.14.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/rpc-augment": "9.9.4",
+        "@polkadot/rpc-provider": "9.9.4",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/rpc-provider": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-8.14.1.tgz",
-      "integrity": "sha512-pAUSHZiSWLhBSYf4LmLc8iCaeqTu7Ajn8AzyqxvZDHGnIrzV5M7eTjpNDP84qno6jWRHKQ/IILr62hausEmS5w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.9.4.tgz",
+      "integrity": "sha512-aUkPtlYukAOFX3FkUgLw3MNy+T0mCiCX7va3PIts9ggK4vl14NFZHurCZq+5ANvknRU4WG8P5teurH9Rd9oDjQ==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-support": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "@polkadot/x-fetch": "^10.1.1",
-        "@polkadot/x-global": "^10.1.1",
-        "@polkadot/x-ws": "^10.1.1",
-        "@substrate/connect": "0.7.9",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-support": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "@polkadot/x-fetch": "^10.1.14",
+        "@polkadot/x-global": "^10.1.14",
+        "@polkadot/x-ws": "^10.1.14",
+        "@substrate/connect": "0.7.17",
         "eventemitter3": "^4.0.7",
         "mock-socket": "^9.1.5",
         "nock": "^13.2.9"
       }
     },
     "@polkadot/types": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-8.14.1.tgz",
-      "integrity": "sha512-Xza16ejKrSd4XhTOlbfISyxZ2sRmbMAZk5pX7VEMHVZHqV98o+bJ2f9Kk7F8YJijkHHGosCLDestP9R5nLoOoA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.9.4.tgz",
+      "integrity": "sha512-/LJ029S0AtKzvV9JoQtIIeHRP/Xoq8MZmDfdHUEgThRd+uvtQzFyGmcupe4EzX0p5VAx93DUFQKm8vUdHE39Tw==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/keyring": "^10.1.1",
-        "@polkadot/types-augment": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/util-crypto": "^10.1.1",
-        "rxjs": "^7.5.6"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/keyring": "^10.1.14",
+        "@polkadot/types-augment": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/util-crypto": "^10.1.14",
+        "rxjs": "^7.5.7"
       }
     },
     "@polkadot/types-augment": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-8.14.1.tgz",
-      "integrity": "sha512-Xa4TUFqyZT+IJ6pBSwDjWcF42u/E34OyC+gbs5Z2vWQ4EzSDkq4xNoUKjJlEEgTemsD9lhPOIc4jvqTCefwxEw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.9.4.tgz",
+      "integrity": "sha512-mQNc0kxt3zM6SC+5hJbsg03fxEFpn5nakki+loE2mNsWr1g+rR7LECagAZ4wT2gvdbzWuY/LlRYyDQxe0PwdZg==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-codec": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-8.14.1.tgz",
-      "integrity": "sha512-y6YDN4HwvEgSWlgrEV04QBBxDxES1cTuUQFzZJzOTuZCWpA371Mdj3M9wYxGXMnj0wa+rCQGECHPZZaNxBMiKg==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.9.4.tgz",
+      "integrity": "sha512-uSHoQQcj4813c9zNkDDH897K6JB0OznTrH5WeZ1wxpjML7lkuTJ2t/GQE9e4q5Ycl7YePZsvEp2qlc3GwrVm/w==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1",
-        "@polkadot/x-bigint": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14",
+        "@polkadot/x-bigint": "^10.1.14"
       }
     },
     "@polkadot/types-create": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-8.14.1.tgz",
-      "integrity": "sha512-fb9yyblj5AYAPzeCIq0kYSfzDxRDi/0ud9gN2UzB3H7M/O4n2mPC1vD4UOLF+B7l9QzCrt4e+k+/riGp7GfvyA==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.9.4.tgz",
+      "integrity": "sha512-EOxLryRQ4JVRSRnIMXk3Tjry1tyegNuWK8OUj51A1wHrX76DF9chME27bXUP4d7el1pjqPuQ9/l+/928GG386g==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-known": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-8.14.1.tgz",
-      "integrity": "sha512-GP7gRo9nmitykkrRnoLF61Qm19UFdTwMsOnJkdm7AOeWDmZGxutacgO6k1tBsHr38hsiCCGsB/JiseUgywvGIw==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.9.4.tgz",
+      "integrity": "sha512-BaKXkg3yZLDv31g0CZPJsZDXX01VTjkQ0tmW9U6fmccEq3zHlxbUiXf3aKlwKRJyDWiEOxr4cQ4GT8jj6uEIuA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/networks": "^10.1.1",
-        "@polkadot/types": "8.14.1",
-        "@polkadot/types-codec": "8.14.1",
-        "@polkadot/types-create": "8.14.1",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/networks": "^10.1.14",
+        "@polkadot/types": "9.9.4",
+        "@polkadot/types-codec": "9.9.4",
+        "@polkadot/types-create": "9.9.4",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/types-support": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-8.14.1.tgz",
-      "integrity": "sha512-XqR4qq6pCZyNBuFVod8nFSNUmLssrjoU9bOIn4Ua2cqNlI9xsuKaI1X5ySEn/oWOtKQ2L5hbCm9vkXrEtXBl1w==",
+      "version": "9.9.4",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.9.4.tgz",
+      "integrity": "sha512-vjhdD7B5kdTLhm2iO0QAb7fM4D2ojNUVVocOJotC9NULYtoC+PkPvkvFbw7VQ1H3u7yxyZfWloMtBnCsIp5EAA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "@polkadot/util": "^10.1.1"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/util": "^10.1.14"
       }
     },
     "@polkadot/util": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.11.tgz",
-      "integrity": "sha512-6m51lw6g6ilqO/k4BQY7rD0lYM9NCnC4FiM7CEEUc7j8q86qxdcZ88zdNldkhNsTIQnfmCtkK3GRzZW6VYrbUw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.1.14.tgz",
+      "integrity": "sha512-DX8IUd3j+S4HJBs73gz5d7Z592aW5vn/aD7hzFUlBduQIYBy+L1KIoGchpD6hSSOs5HSy7owePmBlp1lPjUZBg==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-bigint": "10.1.11",
-        "@polkadot/x-global": "10.1.11",
-        "@polkadot/x-textdecoder": "10.1.11",
-        "@polkadot/x-textencoder": "10.1.11",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-global": "10.1.14",
+        "@polkadot/x-textdecoder": "10.1.14",
+        "@polkadot/x-textencoder": "10.1.14",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       }
     },
     "@polkadot/util-crypto": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.11.tgz",
-      "integrity": "sha512-wG63frIMAR5T/HXGM0SFNzZZdk7qDBsfLXfn6PIZiXCCCsdEYPzS5WltB7fkhicYpbePJ7VgdCAddj1l4IcGyg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.1.14.tgz",
+      "integrity": "sha512-Iq9C0Snv+pScZ9QgJoH7l++x9wdp9vhS3NMLm8ZqlDCNXUUl/3ViafZCfHRILQD9AsLcykE99mNzFDl3u8jZQA==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
+        "@babel/runtime": "^7.20.1",
         "@noble/hashes": "1.1.3",
         "@noble/secp256k1": "1.7.0",
-        "@polkadot/networks": "10.1.11",
-        "@polkadot/util": "10.1.11",
+        "@polkadot/networks": "10.1.14",
+        "@polkadot/util": "10.1.14",
         "@polkadot/wasm-crypto": "^6.3.1",
-        "@polkadot/x-bigint": "10.1.11",
-        "@polkadot/x-randomvalues": "10.1.11",
+        "@polkadot/x-bigint": "10.1.14",
+        "@polkadot/x-randomvalues": "10.1.14",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -8042,67 +8048,67 @@
       }
     },
     "@polkadot/x-bigint": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.11.tgz",
-      "integrity": "sha512-TC4KZ+ni/SJhcf/LIwD49C/kwvACu0nCchETNO+sAfJ7COXZwHDUJXVXmwN5PgkQxwsWsKKuJmzR/Fi1bgMWnQ==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.1.14.tgz",
+      "integrity": "sha512-HgrofhI+WM699ozJ9zFZcPUApB2jqwCEOMUgM1jv2WNxF0ILKNDpH08dB8OBy2SKfnKoSgmXwWtxWl1u+mq10A==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-fetch": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.11.tgz",
-      "integrity": "sha512-WtyUr9itVD9BLnxCUloJ1iwrXOY/lnlEShEYKHcSm6MIHtbJolePd3v1+o5mOX+bdDbHXhPZnH8anCCqDNDRqg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.1.14.tgz",
+      "integrity": "sha512-07H9unwv0tT5RQRkj1WE67ug6x6RlUfGN/mJWSKqf0JjsfQlPMKDC9yZW1oUSsasBUyIf0qbspuVSyhZu+0cpg==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/node-fetch": "^2.6.2",
-        "node-fetch": "^3.2.10"
+        "node-fetch": "^3.3.0"
       }
     },
     "@polkadot/x-global": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.11.tgz",
-      "integrity": "sha512-bWz5gdcELy6+xfr27R1GE5MPX4nfVlchzHQH+DR6OBbSi9g/PeycQAvFB6IkTmP+YEbNNtIpxnSP37zoUaG3xw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.1.14.tgz",
+      "integrity": "sha512-ye3Yx2bfIoHf5t78rbDad587J16JanrcfpGSWoknWOZ7wmatj/CJKWhJ/VKMPfJGEJm2LidH1B0W8QDfrMEmTA==",
       "requires": {
-        "@babel/runtime": "^7.19.4"
+        "@babel/runtime": "^7.20.1"
       }
     },
     "@polkadot/x-randomvalues": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.11.tgz",
-      "integrity": "sha512-V2V37f5hoM5B32eCpGw87Lwstin2+ArXhOZ8ENKncbQLXzbF9yTODueDoA5Vt0MJCs2CDP9cyiCYykcanqVkxg==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.1.14.tgz",
+      "integrity": "sha512-mrZho4qogLZmox7wuP1XF03HTZ4CwAjzV7RvKmwH8ToNCR6E4NRo2btgG67Z0K+bUOQRbXWL2hQazusa2p2N6w==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-textdecoder": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.11.tgz",
-      "integrity": "sha512-QZqie04SR6pAj260PaLBfZUGXWKI357t4ROVJhpaj06qc1zrk1V8Mwkr49+WzjAPFEOqo70HWnzXmPNCH4dQiw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.1.14.tgz",
+      "integrity": "sha512-qwbeR8v6a5Z9MdbjzcY5gFiRWbp8bBVoDEf1Dd+yH9/UAyFXodlMKs3irDdVhGVPCbZWQTVDEZRUgEqRxwKC7w==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-textencoder": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.11.tgz",
-      "integrity": "sha512-UX+uV9AbDID81waaG/NvTkkf7ZNVW7HSHaddgbWjQEVW2Ex4ByccBarY5jEi6cErEPKfzCamKhgXflu0aV9LWw==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.1.14.tgz",
+      "integrity": "sha512-MC30rtQiFVgQDSP8wO5wa1so5tW3T7qs/DCT018A4zgjiK+uFdIGOerAgoxcNw3yC6IGnPIL5lsRO/1C9N60zA==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11"
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14"
       }
     },
     "@polkadot/x-ws": {
-      "version": "10.1.11",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.11.tgz",
-      "integrity": "sha512-EUbL/R1A/NxYf6Rnb1M7U9yeTuo5r4y2vcQllE5aBLaQ0cFnRykHzlmZlVX1E7O5uy3lYVdxWC7sNgxItIWkWA==",
+      "version": "10.1.14",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.1.14.tgz",
+      "integrity": "sha512-xgyMYR34sHxKCtQUJ2btFAyN3fK1OqCqvAyRYmU52801aguLstRhVPAZxXJp3Dahs91FX/h/ZZzmwXD01tJtyA==",
       "requires": {
-        "@babel/runtime": "^7.19.4",
-        "@polkadot/x-global": "10.1.11",
+        "@babel/runtime": "^7.20.1",
+        "@polkadot/x-global": "10.1.14",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       }
@@ -8154,12 +8160,12 @@
       "dev": true
     },
     "@substrate/connect": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.9.tgz",
-      "integrity": "sha512-E6bdBhzsfHNAKlmQSvbTW1jyb0WcIvgbrEBfJ4B6FZ3t1wpGjldL6GrYtegVtKr9/ySQ/pFNn0uVbugukpMDjQ==",
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.7.17.tgz",
+      "integrity": "sha512-s0XBmGpUCFWZFa+TS0TEvOKtWjJP2uT4xKmvzApH8INB5xbz79wqWFX6WWh3AlK/X1P0Smt+RVEH7HQiLJAYAw==",
       "requires": {
         "@substrate/connect-extension-protocol": "^1.0.1",
-        "@substrate/smoldot-light": "0.6.25",
+        "@substrate/smoldot-light": "0.7.7",
         "eventemitter3": "^4.0.7"
       }
     },
@@ -8169,17 +8175,25 @@
       "integrity": "sha512-161JhCC1csjH3GE5mPLEd7HbWtwNSPJBg3p1Ksz9SFlTzj/bgEwudiRN2y5i0MoLGCIJRYKyKGMxVnd29PzNjg=="
     },
     "@substrate/smoldot-light": {
-      "version": "0.6.25",
-      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.6.25.tgz",
-      "integrity": "sha512-OQ9/bnJJy90xSRg5Vp9MIvrgbrVt/r/FwXYSmyLeBBNbJt6o1gSeshVo8icD+2VWwd/TJ2oHl5CVQWe89MyByA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@substrate/smoldot-light/-/smoldot-light-0.7.7.tgz",
+      "integrity": "sha512-ksxeAed6dIUtYSl0f8ehgWQjwXnpDGTIJt+WVRIGt3OObZkA96ZdBWx0xP7GrXZtj37u4n/Y1z7TyTm4bwQvrw==",
       "requires": {
-        "websocket": "^1.0.32"
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+          "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        }
       }
     },
     "@substrate/ss58-registry": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.33.0.tgz",
-      "integrity": "sha512-DztMuMcEfu+tJrtIQIIp5gO8/XJZ8N8UwPObDCSNgrp7trtSkPJAUFB9qXaReXtN9UvTcVBMTWk6VPfFi04Wkg=="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.35.0.tgz",
+      "integrity": "sha512-cIY3J7RlT4mfPNFwd2mv1q9vTp/shImw2gN2y2outMhOcagH/HG+W8/JohpifjxPC/1pbQ0Z8nxfL5Td3EchcA=="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -8653,9 +8667,9 @@
       "dev": true
     },
     "bufferutil": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.6.tgz",
-      "integrity": "sha512-jduaYOYtnio4aIAyc6UbvPCVcgq7nYpVnucyxr6eCYg/Woad9Hf/oxxBRDnGGjPfjUm6j5O/uBWhIu4iLebFaw==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -10893,9 +10907,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
-      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
+      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -11850,9 +11864,9 @@
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -12505,9 +12519,9 @@
       "integrity": "sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A=="
     },
     "utf-8-validate": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.9.tgz",
-      "integrity": "sha512-Yek7dAy0v3Kl0orwMlvi7TPtiCNrdfHNd7Gcc/pLq4BLXqfAmd0J7OWMizUQnTTJsyjKn02mU7anqwfmUP4J8Q==",
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "requires": {
         "node-gyp-build": "^4.3.0"
       }
@@ -12649,6 +12663,12 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "requires": {}
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-ipfs",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Service for DSCP",
   "main": "app/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/digicatapult/dscp-ipfs#readme",
   "dependencies": {
-    "@digicatapult/dscp-node": "^4.4.6",
+    "@polkadot/api": "^9.9.4",
     "dotenv": "^16.0.3",
     "envalid": "^7.3.1",
     "express": "^4.18.2",


### PR DESCRIPTION
Since `dscp-node` was updated to use a more recent tag of Substrate, we no longer need the `dscp-node` extended types config when connecting to the node via polkadot.js  

This means we can remove usage of `@digicatapult/dscp-node` package and replace with direct use of `@polkadot/api`