### PR TITLE
Feature/in 423

### DIFF
--- a/app/utils/ServiceWatcher.js
+++ b/app/utils/ServiceWatcher.js
@@ -10,6 +10,7 @@ class ServiceWatcher {
 
   // TODO add a method for updating this.services
   constructor(apis) {
+    client.register.clear()
     this.report = {}
     this.#pollPeriod = env.HEALTHCHECK_POLL_PERIOD_MS
     this.ipfsApiUrl = `http://${env.IPFS_API_HOST}:${env.IPFS_API_PORT}/api/v0/`
@@ -50,7 +51,6 @@ class ServiceWatcher {
 
   // organize services and store in this.services
   #init(services) {
-    client.register.clear()
     return Object.keys(services)
       .map((service) => {
         const { healthCheck, ...api } = services[service]

--- a/helm/dscp-ipfs/Chart.yaml
+++ b/helm/dscp-ipfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: dscp-ipfs
-appVersion: '2.9.0'
+appVersion: '2.9.1'
 description: A Helm chart for dscp-ipfs
-version: '2.9.0'
+version: '2.9.1'
 type: application
 dependencies:
   - name: dscp-node

--- a/helm/dscp-ipfs/values.yaml
+++ b/helm/dscp-ipfs/values.yaml
@@ -52,7 +52,7 @@ statefulSet:
 image:
   repository: digicatapult/dscp-ipfs
   pullPolicy: IfNotPresent
-  tag: 'v2.9.0'
+  tag: 'v2.9.1'
 
 storage:
   storageClass: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/dscp-ipfs",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^9.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/dscp-ipfs",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Service for DSCP",
   "main": "app/index.js",
   "type": "module",


### PR DESCRIPTION
### What

a couple more metrics have been added to the service watcher.

```
# HELP dscp_ipfs_files_count a number of files (blocks)
# TYPE dscp_ipfs_files_count gauge
dscp_ipfs_files_count 0

# HELP dscp_ipfs_total_files_size a total number of storage used in bytes? TODO confim
# TYPE dscp_ipfs_total_files_size gauge
dscp_ipfs_total_files_size 0

# HELP dscp_ipfs_swarm_peer_count a number of discovered and connected peers
# TYPE dscp_ipfs_swarm_peer_count gauge
dscp_ipfs_swarm_peer_count{type="discovered"} 6
dscp_ipfs_swarm_peer_count{type="connected"} 0
```